### PR TITLE
hotfix: chat entity param (UI + API)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,7 @@ method: 'POST',
 headers: {
 'Content-Type': 'application/json'
 },
-body: JSON.stringify({ message, searchName })
+body: JSON.stringify({ message, entity: searchName })
 });
 
 const data = await response.json();


### PR DESCRIPTION
- UI: send `{ message, entity }` to /api/chat
- API: accept `entity` parameter (compatible with previous `searchName` in earlier builds still on main)

Purpose: Fix production error `{"error":"Message and entity are required"}` reported when frontend sent `searchName`. After merge, Vercel will auto-deploy and the chat should work with entity.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author