### PR TITLE
chore: add NOOP embeddingFunction for Chroma collection

### DIFF
--- a/src/lib/vectorDb.ts
+++ b/src/lib/vectorDb.ts
@@ -17,9 +17,12 @@ const COLLECTION_NAME = 'zoho_crm_context';
  */
 async function getCollection() {
     try {
-        return await chromaClient.getOrCreateCollection({ name: COLLECTION_NAME });
+        // Provide a NOOP embedding function to fully bypass Chroma's DefaultEmbeddingFunction
+        // in serverless environments. We always pass `embeddings` explicitly on upsert/query.
+        const NOOP: any = { generate: async () => { throw new Error('NOOP embedding function used. All operations must provide embeddings explicitly.'); } };
+        return await chromaClient.getOrCreateCollection({ name: COLLECTION_NAME, embeddingFunction: NOOP });
     } catch (error) {
-        console.error("Error getting or creating Chroma collection:", error);
+        console.error('Error getting or creating Chroma collection:', error);
         throw error;
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,7 @@ method: 'POST',
 headers: {
 'Content-Type': 'application/json'
 },
-body: JSON.stringify({ message, searchName })
+body: JSON.stringify({ message, entity: searchName })
 });
 
 const data = await response.json();

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,25 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import { ChromaClient } from 'chromadb';
+
+export const GET: RequestHandler = async () => {
+  const backend = (env.VECTOR_BACKEND || 'chroma').toLowerCase();
+  const health: any = {
+    vector_backend: backend
+  };
+
+  if (backend === 'chroma') {
+    try {
+      const path = env.CHROMA_URL || 'http://localhost:8000';
+      const client = new ChromaClient({ path });
+      const collections = await client.listCollections();
+      health.chroma = { ok: true, url: path, collections_count: collections.length };
+    } catch (e: any) {
+      health.chroma = { ok: false, error: e?.message || String(e) };
+    }
+  }
+
+  return json(health);
+};
+


### PR DESCRIPTION
### **User description**
Pass a NOOP embeddingFunction to `getOrCreateCollection` so Chroma never tries to instantiate DefaultEmbeddingFunction on Vercel. Keeps using OpenAI embeddings for upserts and queryEmbeddings for retrieval.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Chroma collection initialization with NOOP embedding function

- Add health endpoint for production monitoring

- Switch to runtime environment variables for Vercel compatibility

- Refactor OpenAI embedding calls for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] --> B["ChromaClient"]
  B --> C["NOOP Embedding Function"]
  C --> D["Collection Creation"]
  E["OpenAI Embeddings"] --> F["Query/Upsert Operations"]
  G["Health Endpoint"] --> H["Production Monitoring"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vectorDb.ts</strong><dd><code>Fix Chroma initialization and embedding handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/vectorDb.ts

<ul><li>Replace dotenv with SvelteKit runtime environment variables<br> <li> Add NOOP embedding function to bypass Chroma's <br>DefaultEmbeddingFunction<br> <li> Extract embedText helper function for OpenAI embedding calls<br> <li> Refactor queryVectorDb to use embedText helper consistently</ul>


</details>


  </td>
  <td><a href="https://github.com/Faitltd/ZohoLLM/pull/3/files#diff-a73481a43d6ad6f33cddedf433958ff05a132650c3aedac1d71f9876824609b9">+32/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>+server.ts</strong><dd><code>Add health monitoring endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/api/health/+server.ts

<ul><li>Add new health check endpoint for production monitoring<br> <li> Check Chroma connection status and collection count<br> <li> Return JSON response with backend status information</ul>


</details>


  </td>
  <td><a href="https://github.com/Faitltd/ZohoLLM/pull/3/files#diff-0e84f6657e8551334a93aa5995fa3c1ee15a5c01b9dbd31914f45d0c35df4b58">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+page.svelte</strong><dd><code>Update API parameter naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/+page.svelte

<ul><li>Change request body parameter from <code>searchName</code> to <code>entity</code><br> <li> Maintain backward compatibility with existing API structure</ul>


</details>


  </td>
  <td><a href="https://github.com/Faitltd/ZohoLLM/pull/3/files#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

